### PR TITLE
Remove license header.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: BSD-3-clause
-
 Copyright 2020-2021 QuantCo Inc
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
GitHub (`licensee`) doesn't seem to be able to detect that our license is BSD-3-clause. 

https://stackoverflow.com/questions/66258037/github-license-not-recognised