### PR TITLE
Pin antl runtime to 4.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.7.0"
 
 dependencies = [
     "sqlalchemy >=1.4",
-    "antlr4-python3-runtime >=4.9.2",
+    "antlr4-python3-runtime =4.9.2",
     "pyodbc >=4.0.30"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.7.0"
 
 dependencies = [
     "sqlalchemy >=1.4",
-    "antlr4-python3-runtime =4.9.2",
+    "antlr4-python3-runtime ==4.9.2",
     "pyodbc >=4.0.30"
 ]
 


### PR DESCRIPTION
There is a new ANTLR runtime (4.10) which gets installed with the current pinning. Unfortunately, there are reported issues with that version in this package. This PR pins the version to the same as the one defined in the development environment. See [here](https://github.com/conda-forge/pytsql-feedstock/pull/1) for extra context.