### PR TITLE
Fix `CREATE VIEW` not being a first command

### DIFF
--- a/src/pytsql/tsql.py
+++ b/src/pytsql/tsql.py
@@ -88,10 +88,10 @@ class _TSQLVisitor(antlr4.ParseTreeVisitor):
 
         chunks = tree.accept(self)
 
-        # CREATE SCHEMA must be the only statement in a batch
-        if (
-            tree.ddl_clause() is not None
-            and tree.ddl_clause().create_schema() is not None
+        # CREATE SCHEMA/VIEW must be the only statement in a batch
+        if tree.ddl_clause() is not None and (
+            tree.ddl_clause().create_schema() is not None
+            or tree.ddl_clause().create_view() is not None
         ):
             return " ".join(chunks)
 

--- a/tests/unit/test_dynamics.py
+++ b/tests/unit/test_dynamics.py
@@ -29,9 +29,10 @@ def test_dont_append_dynamics_on_create_schema():
         DECLARE @A INT = 5
         CREATE SCHEMA s
         SELECT * FROM x
+        CREATE VIEW y AS SELECT 1
         """
     splits = _split(seed)
-    assert len(splits) == 3
+    assert len(splits) == 4
 
     assert splits[0] == "DECLARE @A INT = 5"
     assert splits[1] == "CREATE SCHEMA s"
@@ -42,3 +43,4 @@ def test_dont_append_dynamics_on_create_schema():
         SELECT * FROM x
         """,
     )
+    assert splits[3] == "CREATE VIEW y AS SELECT 1"


### PR DESCRIPTION
Similarly to `CREATE SCHEMA`, the `CREATE VIEW` command shouldn't have dynamics prepended to it, because it must be the first command in a batch.