### PR TITLE
Fix comment table already exists bug

### DIFF
--- a/src/pytsql/tsql.py
+++ b/src/pytsql/tsql.py
@@ -205,6 +205,9 @@ def executes(
     """
     parametrized_code = _parametrize(code, parameters) if parameters else code
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        # Since the prints table is a temporary one, it will be local to the connection and it will be dropped once the
+        # connection is closed. Caveat: sqlalchemy engines can pool connections, so we still have to drop it preemtively.
+        conn.execute(f"DROP TABLE IF EXISTS {_PRINTS_TABLE}")
         conn.execute(f"CREATE TABLE {_PRINTS_TABLE} (p NVARCHAR(4000))")
         for batch in _split(parametrized_code):
             conn.execute(batch)

--- a/tests/integration/test_prints.py
+++ b/tests/integration/test_prints.py
@@ -79,3 +79,8 @@ def test_print_truncation(engine, caplog):
 
     assert ("a" * 2000) in caplog.text
     assert ("a" * 2001) not in caplog.text
+
+
+def test_multiple_prints(engine):
+    for _ in range(1000):
+        executes("SELECT 12", engine)

--- a/tests/integration/test_prints.py
+++ b/tests/integration/test_prints.py
@@ -82,5 +82,5 @@ def test_print_truncation(engine, caplog):
 
 
 def test_multiple_prints(engine):
-    for _ in range(1000):
+    for _ in range(50):
         executes("SELECT 12", engine)


### PR DESCRIPTION
We get `There is already an object named '#pytsql_prints' in the database.` whenever the same connection is used (e.g. due to pooling in the engine; see [execution logs](https://github.com/Quantco/pytsql/runs/8184317764?check_suite_focus=true#step:8:231)).