### PR TITLE
Fix `antlr4-python3-runtime` pin to keep in sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.7.0"
 
 dependencies = [
     "sqlalchemy >=1.4, <2.0",
-    "antlr4-python3-runtime ==4.11",
+    "antlr4-python3-runtime ==4.11.1",
     "pyodbc >=4.0.30"
 ]
 


### PR DESCRIPTION
**Motivation**: Currently, the pin for `antlr4-python3-runtime` is different between `pyproject.toml` and `environment.yaml`

**Changes**: Keep both in sync by setting it to `4.11.1`