### PR TITLE
Add Windows for unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,8 @@ jobs:
         uses: pre-commit/action@v3.0.0
 
 
-  linux:
-    name: "Linux - unit tests - Python ${{ matrix.PYTHON_VERSION }}"
+  unit-tests:
+    name: "Unit tests - ${{ matrix.OS }} - Python ${{ matrix.PYTHON_VERSION }}"
     runs-on: ubuntu-latest
     env:
       CI: True
@@ -28,6 +28,7 @@ jobs:
       fail-fast: true
       matrix:
         PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
+        OS: ['ubuntu-latest', 'windows-latest']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3


### PR DESCRIPTION
quick one

**Motivation**: Support Windows as well for unit tests (integration tests are a bit more complicated) for [quicker feedback](https://github.com/Quantco/pytsql/pull/73#issuecomment-1482417123)

**Changes**: Add `windows-latest`