### PR TITLE
Add test for parse listener

### DIFF
--- a/tests/unit/test_parse_listener.py
+++ b/tests/unit/test_parse_listener.py
@@ -12,7 +12,6 @@ def test_parser_listener_called_at_enter_tsql_file():
     tree = parse(InputStream(data=seeed), "tsql_file")
     walker = antlr4.ParseTreeWalker()
     test_listener = MagicMock()
-    test_listener.enterTsql_file = MagicMock()
     walker.walk(test_listener, tree)
 
     assert test_listener.enterTsql_file.called


### PR DESCRIPTION
**Motivation**: Follow-up of PR #79, complement the newly added parser listener with a test. An idea by @SimeonStoykovQC 🎉 

**Changes**: Add a test that the (most basic) call of the listener exists & is called during parsing.

