### PR TITLE
feat: Add an option to get receive the batches in a script and be able to execute them.

### DIFF
--- a/src/pytsql/__init__.py
+++ b/src/pytsql/__init__.py
@@ -3,7 +3,7 @@
 import importlib.metadata
 import warnings
 
-from .tsql import execute, executes
+from .tsql import execute, executes, iter_executes_batches
 
 try:
     __version__ = importlib.metadata.version(__name__)
@@ -12,4 +12,4 @@ except importlib.metadata.PackageNotFoundError as e:  # pragma: no cover
     __version__ = "unknown"
 
 
-__all__ = ["execute", "executes"]
+__all__ = ["execute", "executes", "iter_executes_batches"]

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -3,11 +3,16 @@ from pytsql.tsql import iter_executes_batches
 
 def test_executes_batches(engine):
     seed = """
-    CREATE TABLE test_table (
-        col_test VARCHAR(10)
-    );
-    INSERT INTO test_table
-    VALUES (':foo')
+    USE [tempdb]
+    GO
+    DROP TABLE IF EXISTS [test_table]
+    CREATE TABLE [test_table] (
+        col VARCHAR(3)
+    )
+    GO
+    INSERT INTO [test_table] (col)
+    VALUES ('A'), ('AB'), ('ABC')
+    PRINT('Affected ' + CAST(@@ROWCOUNT AS VARCHAR) + ' rows')
     """
 
     for sql, run in iter_executes_batches(seed, engine, None):

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -1,20 +1,21 @@
 from pytsql.tsql import iter_executes_batches
+import logging
 
 
 def test_executes_batches(engine):
     seed = """
     USE [tempdb]
     GO
-    DROP TABLE IF EXISTS [test_table]
-    CREATE TABLE [test_table] (
+    DROP TABLE IF EXISTS [test_table_batches]
+    CREATE TABLE [test_table_batches] (
         col VARCHAR(3)
     )
     GO
-    INSERT INTO [test_table] (col)
+    INSERT INTO [test_table_batches] (col)
     VALUES ('A'), ('AB'), ('ABC')
     PRINT('Affected ' + CAST(@@ROWCOUNT AS VARCHAR) + ' rows')
     """
 
     for sql, run in iter_executes_batches(seed, engine, None):
-        print(sql)
+        logging.info(sql)
         run()

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -21,3 +21,8 @@ def test_executes_batches(engine):
 
     assert len(batches) == 5
     assert "USE [tempdb]" in batches[0]
+
+    with engine.connect() as conn:
+        result = conn.execute("SELECT COUNT(*) FROM test_table_batches")
+        count = result.scalar()
+        assert count == 3

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -1,3 +1,5 @@
+import sqlalchemy as sa
+
 from pytsql.tsql import iter_executes_batches
 
 
@@ -23,6 +25,6 @@ def test_executes_batches(engine):
     assert "USE [tempdb]" in batches[0]
 
     with engine.connect() as conn:
-        result = conn.execute("SELECT COUNT(*) FROM test_table_batches")
+        result = conn.execute(sa.text("SELECT COUNT(*) FROM test_table_batches"))
         count = result.scalar()
         assert count == 3

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -1,7 +1,7 @@
 from pytsql.tsql import iter_executes_batches
 
 
-def test_executes_text_with_semicolon(engine):
+def test_executes_batches(engine):
     seed = """
     CREATE TABLE test_table (
         col_test VARCHAR(10)

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -1,0 +1,15 @@
+from pytsql.tsql import iter_executes_batches
+
+
+def test_executes_text_with_semicolon(engine):
+    seed = """
+    CREATE TABLE test_table (
+        col_test VARCHAR(10)
+    );
+    INSERT INTO test_table
+    VALUES (':foo')
+    """
+
+    for sql, run in iter_executes_batches(seed, engine, None):
+        print(sql)
+        run()

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -19,5 +19,5 @@ def test_executes_batches(engine):
         run()
         batches.append(sql)
 
-    assert len(batches) == 3
-    assert "DROP TABLE IF EXISTS [test_table_batches]" in batches[0]
+    assert len(batches) == 5
+    assert "USE [tempdb]" in batches[0]

--- a/tests/integration/test_iter_executes_batches.py
+++ b/tests/integration/test_iter_executes_batches.py
@@ -1,5 +1,4 @@
 from pytsql.tsql import iter_executes_batches
-import logging
 
 
 def test_executes_batches(engine):
@@ -15,7 +14,10 @@ def test_executes_batches(engine):
     VALUES ('A'), ('AB'), ('ABC')
     PRINT('Affected ' + CAST(@@ROWCOUNT AS VARCHAR) + ' rows')
     """
-
+    batches = []
     for sql, run in iter_executes_batches(seed, engine, None):
-        logging.info(sql)
         run()
+        batches.append(sql)
+
+    assert len(batches) == 3
+    assert "DROP TABLE IF EXISTS [test_table_batches]" in batches[0]

--- a/tests/integration/test_non_isolation_mode.py
+++ b/tests/integration/test_non_isolation_mode.py
@@ -28,10 +28,10 @@ def test_semi_persistent_set(engine, caplog):
     caplog.set_level(logging.INFO)
 
     seed = """
-    DECLARE @A INT = 12
-    DECLARE @B INT = 34
-    SET @A = 56
-    SET @B = 78
+    DECLARE @A INT = 123
+    DECLARE @B INT = 345
+    SET @A = 567
+    SET @B = 789
     PRINT(@A)
     GO
     PRINT(@B)
@@ -39,7 +39,7 @@ def test_semi_persistent_set(engine, caplog):
 
     executes(seed, engine, isolate_top_level_statements=False)
 
-    assert "56" in caplog.text
-    assert "34" in caplog.text
-    assert "12" not in caplog.text
-    assert "78" not in caplog.text
+    assert "567" in caplog.text
+    assert "345" in caplog.text
+    assert "123" not in caplog.text
+    assert "789" not in caplog.text


### PR DESCRIPTION
The function `iter_executes_batches` mimics `executes`, but instead of executing the SQL script internally it produces an iterator over each batch and a callable to execute that batch. 

Useful if you have long SQL files with several queries inside them and would like to do some more granular analysis (for example runtime) on each one rather than the whole file.

EDIT:
I also adjust `test_non_isolation_mode.test_semi_persistent_set` by changing the ints as it fails in a funny way:
```
 '12' is contained here:
    INFO     pytsql:tsql.py:212 SQL PRINT: 56
```
